### PR TITLE
[sparx5] Allow to use IS0 to modify VLAN

### DIFF
--- a/drivers/net/ethernet/microchip/sparx5/sparx5_tc_flower.c
+++ b/drivers/net/ethernet/microchip/sparx5/sparx5_tc_flower.c
@@ -908,6 +908,29 @@ static int sparx5_tc_action_vlan_pop(struct vcap_admin *admin,
 	return err;
 }
 
+static int sparx5_tc_action_vlan_modify_is0(struct vcap_admin *admin,
+	struct vcap_rule *vrule,
+	struct flow_cls_offload *fco,
+	struct flow_action_entry *act,
+	u16 tpid)
+{
+	int err = 0;
+
+	err = vcap_rule_add_action_u32(vrule,
+		VCAP_AF_CLS_VID_SEL,
+		2);
+	if (err)
+		return err;
+
+	err = vcap_rule_add_action_u32(vrule,
+			VCAP_AF_VID_VAL,
+			act->vlan.vid);
+	if (err)
+		return err;
+
+	return 0;
+}
+
 static int sparx5_tc_action_vlan_modify(struct vcap_admin *admin,
 					struct vcap_rule *vrule,
 					struct flow_cls_offload *fco,
@@ -917,6 +940,8 @@ static int sparx5_tc_action_vlan_modify(struct vcap_admin *admin,
 	int err = 0;
 
 	switch (admin->vtype) {
+	case VCAP_TYPE_IS0:
+		return sparx5_tc_action_vlan_modify_is0(admin, vrule,fco, act, tpid);
 	case VCAP_TYPE_ES0:
 		err = vcap_rule_add_action_u32(vrule,
 					       VCAP_AF_PUSH_OUTER_TAG,


### PR DESCRIPTION
This change allows to set up rules for modifying classified VLAN on incoming packets.

Following will set up a rule to assign VLAN 110 to incoming AVTP packets
```
tc filter add dev eth8 ingress protocol 0x22f0 prio 10 handle 1 chain 1000000 flower skip_sw  action vlan modify id 110 action goto chain 1200000
```