### PR TITLE
[sparx5] Fix incorrect register access in SerDes init

### DIFF
--- a/drivers/phy/microchip/sparx5_serdes.c
+++ b/drivers/phy/microchip/sparx5_serdes.c
@@ -2079,9 +2079,9 @@ static int sparx5_sd10g28_apply_params(struct sparx5_serdes_macro *macro,
 		      sd_inst,
 		      SD10G_LANE_LANE_50(sd_index));
 
-	sdx5_rmw(SD10G_LANE_LANE_50_CFG_SSC_RESETB_SET(1),
+	sdx5_inst_rmw(SD10G_LANE_LANE_50_CFG_SSC_RESETB_SET(1),
 		 SD10G_LANE_LANE_50_CFG_SSC_RESETB,
-		 priv,
+		 sd_inst,
 		 SD10G_LANE_LANE_50(sd_index));
 
 	sdx5_rmw(SD_LANE_MISC_SD_125_RST_DIS_SET(params->fx_100),


### PR DESCRIPTION
use sdx5_inst_rmw instead of sdx5_inst_rmw for access to SD10G_LANE_LANE_50