### PR TITLE
[sparx5] Allow restarting PTP

### DIFF
--- a/drivers/net/ethernet/microchip/sparx5/sparx5_netdev.c
+++ b/drivers/net/ethernet/microchip/sparx5/sparx5_netdev.c
@@ -307,6 +307,13 @@ static int sparx5_port_hwtstamp_set(struct net_device *dev,
 	    cfg->source != HWTSTAMP_SOURCE_PHYLIB)
 		return -EOPNOTSUPP;
 
+	if((sparx5_port->ptp_rx_cmd && cfg->rx_filter)) {
+		// Looks like timestamping doesn't get disabled by upper layers
+		// This is a quick workaround, to prevent failing, if the filters
+		// are already enabled.
+		return 0;
+	}
+
 	err = sparx5_ptp_setup_traps(sparx5_port, cfg);
 	if (err)
 		return err;


### PR DESCRIPTION
Looks like once PTP filters are configured, they do not get destroyed,
even once ptp4l is shut down. This will cause a failure on PTP restart.

This change adds a check, to prevent attempts to recreate these filters.