### PR TITLE
net: sparx5: fix skb use-after-free in sparx5_port_xmit_impl

### DIFF
--- a/drivers/net/ethernet/microchip/sparx5/sparx5_packet.c
+++ b/drivers/net/ethernet/microchip/sparx5/sparx5_packet.c
@@ -289,6 +289,7 @@ netdev_tx_t sparx5_port_xmit_impl(struct sk_buff *skb, struct net_device *dev)
 	const struct sparx5_ops *ops;
 	u32 ifh[IFH_LEN];
 	netdev_tx_t ret;
+	unsigned int skb_len = skb->len;
 
 	ops = &sparx5->data->ops;
 
@@ -329,7 +330,7 @@ netdev_tx_t sparx5_port_xmit_impl(struct sk_buff *skb, struct net_device *dev)
 	if (ret < 0)
 		goto drop;
 
-	stats->tx_bytes += skb->len;
+	stats->tx_bytes += skb_len;
 	stats->tx_packets++;
 	sparx5->tx.packets++;
 


### PR DESCRIPTION
121c6672b0191ffcebff4b88ec022c39e0a95789 commit introduced bug with memory handling. In sparx5_port_xmit_impl function after calling sparx5_fdma_xmit or sparx5_inject skb is actually consumed and skb pointer is invalid, however, it used to update statistics. This commit fixes this issue by storing skb->len value before calling for sparx5_fdma_xmit or sparx5_inject.