### PR TITLE
[sparx5] Fix compile of sparx5 systems

### DIFF
--- a/drivers/net/ethernet/microchip/sparx5/Makefile
+++ b/drivers/net/ethernet/microchip/sparx5/Makefile
@@ -16,6 +16,7 @@ sparx5-switch-y  := sparx5_main.o \
 		    sparx5_calendar.o \
 		    sparx5_ethtool.o \
 		    sparx5_fdma.o \
+		    lan969x/lan969x_fdma.o \
 		    sparx5_ptp.o \
 		    sparx5_pgid.o \
 		    sparx5_tc.o \


### PR DESCRIPTION
sparx5_xdp.c makes use of lan969x_fdma_xmit_xdp() function, so the module it is defined in should be included in list of needed objects