### PR TITLE
[sparx5] Use correct index into DEV2G5_MAC_MAXLEN_CFG

### DIFF
--- a/drivers/net/ethernet/microchip/sparx5/sparx5_mtu.c
+++ b/drivers/net/ethernet/microchip/sparx5/sparx5_mtu.c
@@ -22,7 +22,7 @@ static u32 sparx5_mtu_get(struct sparx5_port *port)
 		val = spx5_rd(sparx5, DEVRGMII_MAC_MAXLEN_CFG(idx));
 		return DEVRGMII_MAC_MAXLEN_CFG_MAX_LEN_GET(val);
 	} else if (ops->port_is_2g5(port->portno)) {
-		val = spx5_rd(sparx5, DEV2G5_MAC_MAXLEN_CFG(idx));
+		val = spx5_rd(sparx5, DEV2G5_MAC_MAXLEN_CFG(port->portno));
 		return DEV2G5_MAC_MAXLEN_CFG_MAX_LEN_GET(val);
 	} else if (ops->port_is_5g(port->portno)) {
 		val = spx5_rd(sparx5, DEV5G_MAC_MAXLEN_CFG(idx));
@@ -50,10 +50,11 @@ static void sparx5_mtu_set(struct sparx5_port *port, u32 new_mtu)
 	pr_info("Setting MTU to: %u for portno (idx: %u): %u", new_mtu,
 		port->portno, idx);
 
-	/* All port modules have a 2g5 shadow device. */
+	/* All port modules have a 2g5 shadow device (and DEV2G5
+	  is indexed by port number). */
 	spx5_rmw(DEV2G5_MAC_MAXLEN_CFG_MAX_LEN_SET(hw_mtu),
 		 DEV2G5_MAC_MAXLEN_CFG_MAX_LEN, sparx5,
-		 DEV2G5_MAC_MAXLEN_CFG(idx));
+		 DEV2G5_MAC_MAXLEN_CFG(port->portno));
 
 	if (ops->port_is_5g(port->portno))
 		spx5_rmw(DEV5G_MAC_MAXLEN_CFG_MAX_LEN_SET(hw_mtu),

--- a/drivers/net/ethernet/microchip/sparx5/sparx5_mtu.c
+++ b/drivers/net/ethernet/microchip/sparx5/sparx5_mtu.c
@@ -12,27 +12,19 @@
 static u32 sparx5_mtu_get(struct sparx5_port *port)
 {
 	struct sparx5 *sparx5 = port->sparx5;
-	const struct sparx5_ops *ops;
-	u32 idx, val;
+	const struct sparx5_ops *ops = &sparx5->data->ops;
+	u32 val;
 
-	ops = &sparx5->data->ops;
-	idx = ops->port_get_dev_index(sparx5, port->portno);
-
+	/* We always set 2G5 MTU, so there is no point in trying to
+	   read high-speed MAC MTU here */
 	if (ops->port_is_rgmii(port->portno)) {
+		const struct sparx5_ops *ops = &sparx5->data->ops;
+		u32 idx = ops->port_get_dev_index(sparx5, port->portno);
 		val = spx5_rd(sparx5, DEVRGMII_MAC_MAXLEN_CFG(idx));
 		return DEVRGMII_MAC_MAXLEN_CFG_MAX_LEN_GET(val);
-	} else if (ops->port_is_2g5(port->portno)) {
+	} else {
 		val = spx5_rd(sparx5, DEV2G5_MAC_MAXLEN_CFG(port->portno));
 		return DEV2G5_MAC_MAXLEN_CFG_MAX_LEN_GET(val);
-	} else if (ops->port_is_5g(port->portno)) {
-		val = spx5_rd(sparx5, DEV5G_MAC_MAXLEN_CFG(idx));
-		return DEV5G_MAC_MAXLEN_CFG_MAX_LEN_GET(val);
-	} else if (ops->port_is_10g(port->portno)) {
-		val = spx5_rd(sparx5, DEV10G_MAC_MAXLEN_CFG(idx));
-		return DEV10G_MAC_MAXLEN_CFG_MAX_LEN_GET(val);
-	} else {
-		val = spx5_rd(sparx5, DEV25G_MAC_MAXLEN_CFG(idx));
-		return DEV25G_MAC_MAXLEN_CFG_MAX_LEN_GET(val);
 	}
 }
 
@@ -56,7 +48,11 @@ static void sparx5_mtu_set(struct sparx5_port *port, u32 new_mtu)
 		 DEV2G5_MAC_MAXLEN_CFG_MAX_LEN, sparx5,
 		 DEV2G5_MAC_MAXLEN_CFG(port->portno));
 
-	if (ops->port_is_5g(port->portno))
+	if (ops->port_is_rgmii(port->portno)) {
+		spx5_rmw(DEVRGMII_MAC_MAXLEN_CFG_MAX_LEN_SET(hw_mtu),
+			DEVRGMII_MAC_MAXLEN_CFG_MAX_LEN, sparx5,
+			DEVRGMII_MAC_MAXLEN_CFG(idx));
+	} else if (ops->port_is_5g(port->portno))
 		spx5_rmw(DEV5G_MAC_MAXLEN_CFG_MAX_LEN_SET(hw_mtu),
 			 DEV5G_MAC_MAXLEN_CFG_MAX_LEN, sparx5,
 			 DEV5G_MAC_MAXLEN_CFG(idx));


### PR DESCRIPTION
DEV2G5_* registers are indexed by port number, not by index within port family (1G vs. 5G vs. 10G vs 25G ports)

This change fixes setting MTU on ports in 1G mode.