### PR TITLE
RFC: net: dsa: lan9645x: add multi-bridge support

### DIFF
--- a/drivers/net/dsa/microchip/lan9645x/lan9645x_main.c
+++ b/drivers/net/dsa/microchip/lan9645x/lan9645x_main.c
@@ -750,6 +750,7 @@ static int lan9645x_setup(struct dsa_switch *ds)
 	ds->mtu_enforcement_ingress = true;
 	ds->assisted_learning_on_cpu_port = true;
 	ds->fdb_isolation = true;
+	ds->max_num_bridges = VLAN_HSR_PRP - 1;
 
 	if (lan9645x->ptp) {
 		err = devm_request_threaded_irq(dev, lan9645x->ptp_irq, NULL,
@@ -843,11 +844,16 @@ static struct net_device *lan9645x_classify_db(struct dsa_db db)
 
 u16 lan9645x_vlan_unaware_pvid(struct lan9645x *lan9645x, struct net_device *bridge)
 {
-	/* Logic must reflect lan9645x_vlan_port_get_pvid */
+	struct dsa_port *dp;
+
 	if (!bridge)
 		return HOST_PVID;
 
-	return UNAWARE_PVID;
+	dsa_switch_for_each_port(dp, lan9645x->ds)
+		if (dsa_port_bridge_dev_get(dp) == bridge)
+			return dsa_port_bridge_num_get(dp);
+
+	return HOST_PVID;
 }
 
 void lan9645x_port_set_learning(struct lan9645x *lan9645x, int port, bool enabled)
@@ -1006,6 +1012,29 @@ static int lan9645x_port_bridge_flags(struct dsa_switch *ds, int port,
 	return 0;
 }
 
+static u32 lan9645x_get_bridge_fwd_mask(struct lan9645x *lan9645x,
+					struct lan9645x_port *src)
+{
+	struct dsa_port *src_dp = dsa_to_port(lan9645x->ds, src->chip_port);
+	struct net_device *br = dsa_port_bridge_dev_get(src_dp);
+	struct lan9645x_port *p;
+	u32 mask = 0;
+	int port;
+
+	if (!br)
+		return 0;
+
+	lan9645x_for_each_port(lan9645x, port, p) {
+		struct dsa_port *dp = dsa_to_port(lan9645x->ds, port);
+
+		if (p->stp_state == BR_STATE_FORWARDING &&
+		    dsa_port_bridge_dev_get(dp) == br)
+			mask |= BIT(p->chip_port);
+	}
+
+	return mask & ~BIT(src->chip_port);
+}
+
 void lan9645x_update_fwd_mask(struct lan9645x *lan9645x, bool joining)
 {
 	struct lan9645x_port *p;
@@ -1026,8 +1055,7 @@ void lan9645x_update_fwd_mask(struct lan9645x *lan9645x, bool joining)
 		shadow_of = lan9645x_port_shadow_of(p);
 
 		if (lan9645x_port_is_bridged(p)) {
-			mask = lan9645x->bridge_mask &
-			       lan9645x->bridge_fwd_mask & ~BIT(p->chip_port);
+			mask = lan9645x_get_bridge_fwd_mask(lan9645x, p);
 
 			if (p->bond)
 				mask &= ~lan9645x_lag_dev_get_mask(lan9645x,
@@ -1127,24 +1155,26 @@ static int lan9645x_port_bridge_join(struct dsa_switch *ds, int port,
 {
 	struct lan9645x *lan9645x = ds->priv;
 	struct lan9645x_port *lan9645x_port = lan9645x->ports[port];
+	u16 pvid = bridge.num;
 
-	dev_dbg(lan9645x->dev, "port_bridge_join port=%d\n", port);
-
-	if (lan9645x->bridge && lan9645x->bridge != bridge.dev) {
-		NL_SET_ERR_MSG_MOD(extack, "Only one bridge supported");
-		return -EBUSY;
-	}
+	dev_dbg(lan9645x->dev, "port_bridge_join port=%d bridge_num=%u\n",
+		port, pvid);
 
 	mutex_lock(&lan9645x->fwd_domain_lock);
-
-	if (!lan9645x->bridge_mask)
-		lan9645x->bridge = bridge.dev;
 
 	/* The bridge puts ports in IFF_ALLMULTI before calling
 	 * port_bridge_join, so clean up before the port is marked as bridged.
 	 */
 	__lan9645x_port_set_host_flood(lan9645x, port, false, false);
-	lan9645x->bridge_mask |= BIT(lan9645x_port->chip_port);
+
+	/* Set up VLAN table entry for per-bridge PVID */
+	lan9645x->vlan_mask[pvid] |= BIT(lan9645x_port->chip_port) |
+				      BIT(CPU_PORT);
+	lan9645x->vlan_flags[pvid] |= LAN9645X_VLAN_SEC_FWD_ENA;
+	lan9645x_vlan_set_mask(lan9645x, pvid);
+	lan9645x_vlan_cpu_set_vlan(lan9645x, pvid);
+
+	*tx_fwd_offload = true;
 
 	mutex_unlock(&lan9645x->fwd_domain_lock);
 
@@ -1163,11 +1193,6 @@ void lan9645x_port_stp_state_set(struct lan9645x *lan9645x, int port,
 
 	p->stp_state = state;
 
-	if (state == BR_STATE_FORWARDING)
-		lan9645x->bridge_fwd_mask |= BIT(p->chip_port);
-	else
-		lan9645x->bridge_fwd_mask &= ~BIT(p->chip_port);
-
 	learn_ena =
 		(state == BR_STATE_LEARNING || state == BR_STATE_FORWARDING) &&
 		p->learn_ena;
@@ -1176,8 +1201,7 @@ void lan9645x_port_stp_state_set(struct lan9645x *lan9645x, int port,
 		ANA_PORT_CFG_LEARN_ENA, lan9645x,
 		ANA_PORT_CFG(p->chip_port));
 
-	dev_dbg(lan9645x->dev, "port=%d state=%u fwd_mask=0x%x\n", port, state,
-		lan9645x->bridge_fwd_mask);
+	dev_dbg(lan9645x->dev, "port=%d state=%u\n", port, state);
 	lan9645x_update_fwd_mask(lan9645x, state == BR_STATE_FORWARDING);
 	mutex_unlock(&lan9645x->fwd_domain_lock);
 }
@@ -1196,15 +1220,24 @@ static void lan9645x_port_bridge_leave(struct dsa_switch *ds, int port,
 {
 	struct lan9645x *lan9645x = ds->priv;
 	struct lan9645x_port *lan9645x_port = lan9645x->ports[port];
+	u16 pvid = bridge.num;
+	u16 user_mask;
 
-	dev_dbg(lan9645x->dev, "port_bridge_leave port=%d\n", port);
+	dev_dbg(lan9645x->dev, "port_bridge_leave port=%d bridge_num=%u\n",
+		port, pvid);
 
 	mutex_lock(&lan9645x->fwd_domain_lock);
 
-	lan9645x->bridge_mask &= ~BIT(lan9645x_port->chip_port);
+	lan9645x->vlan_mask[pvid] &= ~BIT(lan9645x_port->chip_port);
 
-	if (!lan9645x->bridge_mask)
-		lan9645x->bridge = NULL;
+	/* If no user ports remain in this bridge PVID, clean up */
+	user_mask = lan9645x->vlan_mask[pvid] & ~BIT(CPU_PORT);
+	if (!user_mask) {
+		lan9645x->vlan_mask[pvid] = 0;
+		lan9645x->vlan_flags[pvid] &= ~LAN9645X_VLAN_SEC_FWD_ENA;
+		lan9645x_vlan_cpu_clear_vlan(lan9645x, pvid);
+	}
+	lan9645x_vlan_set_mask(lan9645x, pvid);
 
 	lan9645x_vlan_set_hostmode(lan9645x_port);
 	lan9645x_update_fwd_mask(lan9645x, false);

--- a/drivers/net/dsa/microchip/lan9645x/lan9645x_main.h
+++ b/drivers/net/dsa/microchip/lan9645x/lan9645x_main.h
@@ -472,9 +472,6 @@ struct lan9645x {
 	struct list_head mac_entries;
 	struct mutex mact_lock; /* lock access to mact_table */
 	struct mutex mac_entry_lock; /* lock for mac_entries list */
-	struct net_device *bridge; /* Only support single bridge */
-	u16 bridge_mask; /* Mask for bridged ports */
-	u16 bridge_fwd_mask; /* Mask for forwarding bridged ports */
 	struct mutex fwd_domain_lock; /* lock forwarding configuration */
 
 	/* VLAN */
@@ -778,10 +775,13 @@ lan9645x_chipport_to_ndev(struct lan9645x *lan9645x, int port)
 
 static inline bool lan9645x_port_is_bridged(struct lan9645x_port *p)
 {
+	struct dsa_port *dp;
+
 	if (!p)
 		return false;
 
-	return !!(p->lan9645x->bridge_mask & BIT(p->chip_port));
+	dp = dsa_to_port(p->lan9645x->ds, p->chip_port);
+	return !!dsa_port_bridge_dev_get(dp);
 }
 
 static inline bool lan9645x_port_is_used(struct lan9645x *lan9645x, int port)
@@ -939,7 +939,6 @@ void lan9645x_pcs_get_state(struct phylink_pcs *pcs,
 			    struct phylink_link_state *state);
 
 /* lan9645x_main.c */
-bool lan9645x_port_is_bridged(struct lan9645x_port *p);
 u16 lan9645x_vlan_unaware_pvid(struct lan9645x *lan9645x,
 			       struct net_device *bridge);
 void lan9645x_port_set_learning(struct lan9645x *lan9645x, int port,

--- a/drivers/net/dsa/microchip/lan9645x/lan9645x_mdb.c
+++ b/drivers/net/dsa/microchip/lan9645x/lan9645x_mdb.c
@@ -27,6 +27,21 @@ struct lan9645x_mdb_entry {
 	struct lan9645x_pgid_entry *pgid;
 };
 
+/* Get the port mask of all ports belonging to the bridge identified by VID.
+ * For VLAN-unaware bridges, VID == bridge.num assigned by DSA core.
+ */
+static u16 lan9645x_get_bridge_port_mask(struct lan9645x *lan9645x, u16 vid)
+{
+	struct dsa_port *dp;
+	u16 mask = 0;
+
+	dsa_switch_for_each_user_port(dp, lan9645x->ds)
+		if (dsa_port_bridge_num_get(dp) == vid)
+			mask |= BIT(dp->index);
+
+	return mask;
+}
+
 void lan9645x_mdb_deinit(struct lan9645x *lan9645x)
 {
 	mutex_destroy(&lan9645x->mdb_lock);
@@ -267,7 +282,9 @@ static int __lan9645x_mdb_add(struct lan9645x *lan9645x, int chip_port,
 	mdb_entry->ports |= BIT(chip_port);
 
 	/* Encode mac for IP mc and update hw_ports */
-	lan9645x_mdb_encode_mac(mac, mdb_entry, type, lan9645x->mrouter_mask);
+	lan9645x_mdb_encode_mac(mac, mdb_entry, type,
+				lan9645x->mrouter_mask &
+				lan9645x_get_bridge_port_mask(lan9645x, vid));
 
 	/* Update PGID ptr for non-IP entries (L2 multicast) */
 	old_pgid = mdb_entry->pgid;
@@ -310,7 +327,9 @@ static int __lan9645x_mdb_del(struct lan9645x *lan9645x, int chip_port,
 	mdb_entry->ports &= ~BIT(chip_port);
 
 	/* Encode mac for IP mc and update hw_ports */
-	lan9645x_mdb_encode_mac(mac, mdb_entry, type, lan9645x->mrouter_mask);
+	lan9645x_mdb_encode_mac(mac, mdb_entry, type,
+				lan9645x->mrouter_mask &
+				lan9645x_get_bridge_port_mask(lan9645x, vid));
 
 	/* Update PGID ptr for non-IP entries (L2 multicast) */
 	old_pgid = mdb_entry->pgid;
@@ -416,16 +435,20 @@ int lan9645x_mdb_port_mrouter_set(struct lan9645x *lan9645x, int port,
 	lan9645x_port_pgid_set(lan9645x, PGID_MCIPV6, port, enable);
 
 	/* Known IP mc in data-path is forwarded to router ports by merging the
-	 * mdb port group mask with the mrouter mask.
+	 * mdb port group mask with the mrouter mask, scoped per bridge.
 	 */
 	list_for_each_entry(mdb, &lan9645x->mdb_entries, list) {
+		u16 bridge_ports = lan9645x_get_bridge_port_mask(lan9645x,
+								 mdb->vid);
+		u16 scoped_mrouter = lan9645x->mrouter_mask & bridge_ports;
+
 		/* Merged forwarding mask is unchanged. */
-		if ((mdb->ports | lan9645x->mrouter_mask) == mdb->hw_ports)
+		if ((mdb->ports | scoped_mrouter) == mdb->hw_ports)
 			continue;
 
 		/* Encode port mask in MAC for IP mc and update mdb hw_ports */
 		type = lan9645x_mdb_classify(mdb->mac);
-		lan9645x_mdb_encode_mac(mac, mdb, type, lan9645x->mrouter_mask);
+		lan9645x_mdb_encode_mac(mac, mdb, type, scoped_mrouter);
 
 		/* We handle PGID using entries below (L2 multicast) */
 		if (mdb->pgid)
@@ -439,15 +462,29 @@ int lan9645x_mdb_port_mrouter_set(struct lan9645x *lan9645x, int port,
 				    mdb->vid, type);
 	}
 
-	/* Update shared pgid entries used by L2 multicast with mrouter mask */
+	/* Update shared pgid entries used by L2 multicast with mrouter mask.
+	 * Scope mrouter_mask per bridge using the PGID's first member port.
+	 */
 	list_for_each_entry(pgid_entry, &lan9645x->pgid_entries, list) {
+		struct dsa_port *dp;
+		u16 scoped_mrouter;
+		int first_port;
+
+		if (!pgid_entry->ports)
+			continue;
+
+		first_port = __ffs(pgid_entry->ports);
+		dp = dsa_to_port(lan9645x->ds, first_port);
+		scoped_mrouter = lan9645x->mrouter_mask &
+				 lan9645x_get_bridge_port_mask(lan9645x,
+					dsa_port_bridge_num_get(dp));
+
 		/* Merged forwarding mask is unchanged. */
-		if ((pgid_entry->ports | lan9645x->mrouter_mask) ==
+		if ((pgid_entry->ports | scoped_mrouter) ==
 		    pgid_entry->hw_ports)
 			continue;
 
-		pgid_entry->hw_ports = pgid_entry->ports |
-				       lan9645x->mrouter_mask;
+		pgid_entry->hw_ports = pgid_entry->ports | scoped_mrouter;
 
 		lan_wr(ANA_PGID_PGID_SET(pgid_entry->hw_ports),
 		       lan9645x,

--- a/drivers/net/dsa/microchip/lan9645x/lan9645x_vlan.c
+++ b/drivers/net/dsa/microchip/lan9645x/lan9645x_vlan.c
@@ -120,10 +120,13 @@ static bool lan9645x_vlan_cpu_member_cpu_vlan_mask(struct lan9645x *lan9645x,
 
 static u16 lan9645x_vlan_port_get_pvid(struct lan9645x_port *port)
 {
+	struct dsa_port *dp;
+
 	if (!lan9645x_port_is_bridged(port))
 		return HOST_PVID;
 
-	return port->vlan_aware ? port->pvid : UNAWARE_PVID;
+	dp = dsa_to_port(port->lan9645x->ds, port->chip_port);
+	return port->vlan_aware ? port->pvid : dsa_port_bridge_num_get(dp);
 }
 
 void lan9645x_vlan_port_set_vid(struct lan9645x_port *p, u16 vid, bool pvid,
@@ -317,17 +320,14 @@ void lan9645x_vlan_init(struct lan9645x *lan9645x)
 		lan9645x_vlan_set_mask(lan9645x, vid);
 	}
 
-	/* Set all the ports + cpu to be part of HOST_PVID and UNAWARE_PVID */
+	/* Set all the ports + cpu to be part of HOST_PVID */
 	lan9645x->vlan_mask[HOST_PVID] = all_ports;
 	lan9645x_vlan_set_mask(lan9645x, HOST_PVID);
 
-	lan9645x->vlan_mask[UNAWARE_PVID] = all_ports;
-	lan9645x_vlan_set_mask(lan9645x, UNAWARE_PVID);
-
-	lan9645x_vlan_cpu_set_vlan(lan9645x, UNAWARE_PVID);
+	lan9645x_vlan_cpu_set_vlan(lan9645x, HOST_PVID);
 
 	/* Configure the CPU port to be vlan aware */
-	lan_wr(ANA_VLAN_CFG_VLAN_VID_SET(UNAWARE_PVID) |
+	lan_wr(ANA_VLAN_CFG_VLAN_VID_SET(HOST_PVID) |
 	       ANA_VLAN_CFG_VLAN_AWARE_ENA_SET(1) |
 	       ANA_VLAN_CFG_VLAN_POP_CNT_SET(1),
 	       lan9645x, ANA_VLAN_CFG(CPU_PORT));


### PR DESCRIPTION
This is RFC, can we have multiple bridges and what would be at loss when enabling multi-bridge support?

Remove single-bridge limitation by leveraging DSA core bridge numbering. Each bridge gets a unique PVID (bridge.num ∈ [1..4093]) instead of the shared UNAWARE_PVID=0.

- Set ds->max_num_bridges so DSA assigns per-bridge numbers
- Remove bridge/bridge_mask/bridge_fwd_mask from struct lan9645x
- Compute forwarding masks on-the-fly per bridge (ocelot pattern) instead of maintaining global bridge_mask & bridge_fwd_mask
- Set up per-bridge VLAN table entries in bridge_join/leave with VLAN_SEC_FWD_ENA to prevent cross-bridge unicast leakage
- Enable tx_fwd_offload for each bridge
- Scope mrouter_mask per-bridge when merging into MDB/PGID entries
- Use HOST_PVID as CPU port default instead of UNAWARE_PVID