### PR TITLE
Fix skb data corruption on broadcast across multiple interfaces

### DIFF
--- a/drivers/net/ethernet/vitesse/vtss_if_mux_dev.c
+++ b/drivers/net/ethernet/vitesse/vtss_if_mux_dev.c
@@ -99,7 +99,7 @@ static int internal_dev_xmit(struct sk_buff *skb, struct net_device *netdev) {
         goto DO_CNT;
     }
 
-    if (skb_headroom(skb) < ifh_encap_len) {
+    if (skb_cow_head(skb, ifh_encap_len)) {
         tx_ok = 0;
         pr_info("Not enough room for VTSS-header: %u\n",
                skb_headroom(skb));


### PR DESCRIPTION
I encountered this bug when attempting to send broadcast traffic on multiple vtss.vlan.x interfaces simultaneously. 

The current driver implementation modifies the socket buffer when adding the IFH and VLAN tags. This method works fine when there's only one interface using the buffer, but breaks when shared across two or more interfaces (in my case, using a bridge interface to send out broadcast traffic on multiple vtss.vlan.x interfaces). The data in the socket buffer becomes corrupted for any subsequent calls to internal_dev_xmit() and prevents the packets from being delivered or responded to correctly.

The fix is to use skb_cow_head() to both ensure sufficient headroom and copy the buffer before pushing IFH and VLAN tags into it, instead of checking against and modifying the original buffer.